### PR TITLE
fix configuration options handling when passing integers or boolean values

### DIFF
--- a/lib/middleman-livereload.rb
+++ b/lib/middleman-livereload.rb
@@ -4,8 +4,10 @@ require "guard/livereload"
 Middleman::Guard.add_guard do |options, livereload|
   if livereload
     livereload_options_hash = ""
+    
     livereload.each do |k,v|
-      livereload_options_hash << ", :#{k} => '#{v}'"
+      livereload_options_hash << ", :#{k} => "
+      livereload_options_hash << ((v.kind_of?(String)) ? "'#{v}'" : "#{v.to_s}")
     end
     
     %Q{


### PR DESCRIPTION
The engine interprets the initialization options as string when passing integers or boolean values.

ie.:
:apply_js_live => false, :apply_css_live => false
becomes
:apply_js_live => 'false', :apply_css_live => 'false'
