### PR TITLE
Configuration option for disabling Flash polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Whether live reload should attempt to reload javascript / css 'in-place', withou
 
 A delay middleman-livereload should wait before reacting on file change / deletion notification (sec). Default is 0.
 
+#### `:no_swf`
+
+Disable Flash polyfil for browsers that support native WebSockets.
+
 ## Build & Dependency Status
 
 [![Gem Version](https://badge.fury.io/rb/middleman-livereload.png)][gem]

--- a/lib/middleman-livereload/extension_3_0.rb
+++ b/lib/middleman-livereload/extension_3_0.rb
@@ -13,7 +13,8 @@ module Middleman
           :port => '35729',
           :apply_js_live => true,
           :apply_css_live => true,
-          :grace_period => 0
+          :grace_period => 0,
+          :no_swf => false
         }.merge(options)
 
         app.ready do
@@ -49,7 +50,7 @@ module Middleman
               @@reactor.reload_browser("#{Dir.pwd}/#{file}")
             end
 
-            use ::Rack::LiveReload, :port => options[:port].to_i, :host => options[:host]
+            use ::Rack::LiveReload, :port => options[:port].to_i, :host => options[:host], :no_swf => options[:no_swf]
           end
         end
       end

--- a/lib/middleman-livereload/extension_3_1.rb
+++ b/lib/middleman-livereload/extension_3_1.rb
@@ -8,6 +8,7 @@ module Middleman
     option :apply_js_live, true, 'Apply JS changes live, without reloading'
     option :apply_css_live, true, 'Apply CSS changes live, without reloading'
     option :grace_period, 0, 'Time (in seconds) to wait before reloading'
+    option :no_swf, false, 'Disable Flash WebSocket polyfill for browsers that support native WebSockets'
 
     def initialize(app, options_hash={}, &block)
       super
@@ -20,6 +21,7 @@ module Middleman
       grace_period = options.grace_period
       port = options.port.to_i
       host = options.host
+      no_swf = options.no_swf
       options_hash = options.to_h
 
       app.ready do
@@ -56,7 +58,7 @@ module Middleman
           @reactor.reload_browser("#{Dir.pwd}/#{file}")
         end
 
-        use ::Rack::LiveReload, :port => port, :host => host
+        use ::Rack::LiveReload, :port => port, :host => host, :no_swf => no_swf
       end
     end
   end


### PR DESCRIPTION
I got annoyed watching the "Enabled SWF" placeholder flicker in Chrome every time I made a change to a webpage, so I added the `:no_swf` option to the `Rack::Livereload` configurators to make it easier for folks to ditch Flash.
