### PR TITLE
Fix em-websocket error on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@ middleman init MY_PROJECT
 
 If you already have a Middleman project: Add `gem "middleman-livereload", "~> 3.1.0"` to your `Gemfile` and run `bundle install`
 
-#### Windows users:
-You currently need to add `gem "em-websocket", github: "igrigorik/em-websocket"` to your `Gemfile` and run `bundle install`
-
 ## Configuration
 
 ```

--- a/middleman-livereload.gemspec
+++ b/middleman-livereload.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
   s.add_dependency("middleman-core", ["~> 3.2"])
   s.add_runtime_dependency('rack-livereload', ['~> 0.3.15'])
-  s.add_runtime_dependency('em-websocket', ['~> 0.5.0'])
+  s.add_runtime_dependency('em-websocket', ['~> 0.5.1'])
 end


### PR DESCRIPTION
A new version of `em-websocket` was released [yesterday](https://github.com/igrigorik/em-websocket/issues/115).

Fixes https://github.com/middleman/middleman-livereload/issues/39 and https://github.com/middleman/middleman-livereload/issues/34
