### PR TITLE
Fall back to localhost if there's no private IP

### DIFF
--- a/lib/middleman-livereload/extension_3_1.rb
+++ b/lib/middleman-livereload/extension_3_1.rb
@@ -7,7 +7,7 @@ module Middleman
     option :apply_js_live, true, 'Apply JS changes live, without reloading'
     option :apply_css_live, true, 'Apply CSS changes live, without reloading'
     option :no_swf, false, 'Disable Flash WebSocket polyfill for browsers that support native WebSockets'
-    option :host, Socket.ip_address_list.find(&:ipv4_private?).ip_address, 'Host to bind LiveReload API server to'
+    option :host, Socket.ip_address_list.find(->{ Addrinfo.ip 'localhost' }, &:ipv4_private?).ip_address, 'Host to bind LiveReload API server to'
 
     def initialize(app, options_hash={}, &block)
       super


### PR DESCRIPTION
Livereload works on both localhost and other IPs, this line adds an alternative mobile-friendly IP to test on.
When it can't find a compatible IP it raises an error instead of falling back to localhost, this patch fixes that bug.

Re: https://github.com/middleman/middleman-livereload/issues/56#issuecomment-41356232
