### PR TITLE
Add js_host and js_port options

### DIFF
--- a/lib/middleman-livereload/extension_3_1.rb
+++ b/lib/middleman-livereload/extension_3_1.rb
@@ -3,13 +3,15 @@ require 'middleman-livereload/reactor'
 
 module Middleman
   class LiveReloadExtension < Extension
-    option :port, '35729', 'Port to bind the LiveReload API server to'
+    option :port, '35729', 'Port to bind the LiveReload API server to listen to'
     option :apply_js_live, true, 'Apply JS changes live, without reloading'
     option :apply_css_live, true, 'Apply CSS changes live, without reloading'
     option :no_swf, false, 'Disable Flash WebSocket polyfill for browsers that support native WebSockets'
     option :host, Socket.ip_address_list.find(->{ Addrinfo.ip 'localhost' }, &:ipv4_private?).ip_address, 'Host to bind LiveReload API server to'
     option :ignore, [], 'Array of patterns for paths that must be ignored'
     option :bundle_file_css, 'stylesheets/application.css', 'File to load when a CSS partial was modified'
+    option :js_port, nil, 'Port to connect the LiveReload Javascript to (if different than :port)'
+    option :js_host, nil, 'Host to connect LiveReload Javascript to (if different than :host)'
 
     def initialize(app, options_hash={}, &block)
       super
@@ -24,6 +26,8 @@ module Middleman
 
       port = options.port.to_i
       host = options.host
+      js_port = options.js_port || port
+      js_host = options.js_host || host
       no_swf = options.no_swf
       ignore = options.ignore
       bundle_file_css = options.bundle_file_css
@@ -72,7 +76,7 @@ module Middleman
 
         # Use the vendored livereload.js source rather than trying to get it from Middleman
         # https://github.com/johnbintz/rack-livereload#which-livereload-script-does-it-use
-        use ::Rack::LiveReload, port: port, host: host, no_swf: no_swf, source: :vendored, ignore: ignore
+        use ::Rack::LiveReload, port: js_port, host: js_host, no_swf: no_swf, source: :vendored, ignore: ignore
       end
     end
   end


### PR DESCRIPTION
I've been trying to make livereload work on a docker instance and ran into a small snag: the port at the frontend was not the port the Rack middleware had to listen to. This because the docker machine proxied the port to the docker instance.

As a solution I've added 2 new options that allow for specifying of a separate port and host for the JS from the Rack middleware. 