### PR TITLE
Fix Thread.exclusive deprecation in Ruby 2.3.0

### DIFF
--- a/lib/middleman-livereload/reactor.rb
+++ b/lib/middleman-livereload/reactor.rb
@@ -11,14 +11,15 @@ module Middleman
         @web_sockets = []
         @options     = options
         @thread      = start_threaded_reactor(options)
+        @mutex       = Thread::Mutex.new
       end
 
       def app= app
-        Thread.exclusive { @app = app }
+        @mutex.synchronize { @app = app }
       end
 
       def logger
-        Thread.exclusive { @app.logger }
+        @mutex.synchronize { @app.logger }
       end
 
       def stop


### PR DESCRIPTION
`Thread.exclusive` is deprecated since Ruby 2.3.0. Calling this method generates a lot of error messages in server console as below:

```
Thread.exclusive is deprecated, use Mutex
```

This PR tries to address this issue.