### PR TITLE
Update to middleman 4.1.1 and fix :ignore option

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "middleman", github: "middleman/middleman", branch: "master"
+gem "middleman", "~> 4.1.1"
 
 # Specify your gem's dependencies in middleman-blog.gemspec
 gemspec

--- a/lib/middleman-livereload.rb
+++ b/lib/middleman-livereload.rb
@@ -1,7 +1,7 @@
 require "middleman-core"
 require "middleman-livereload/version"
-  
+
 ::Middleman::Extensions.register(:livereload) do
-  require "middleman-livereload/extension_3_1"
+  require "middleman-livereload/extension"
   ::Middleman::LiveReloadExtension
 end

--- a/lib/middleman-livereload/extension.rb
+++ b/lib/middleman-livereload/extension.rb
@@ -6,7 +6,7 @@ module Middleman
     option :port, '35729', 'Port to bind the LiveReload API server to listen to'
     option :apply_js_live, true, 'Apply JS changes live, without reloading'
     option :apply_css_live, true, 'Apply CSS changes live, without reloading'
-    option :no_swf, false, 'Disable Flash WebSocket polyfill for browsers that support native WebSockets'
+    option :no_swf, true, 'Disable Flash WebSocket polyfill for browsers that support native WebSockets'
     option :host, Socket.ip_address_list.find(->{ Addrinfo.ip 'localhost' }, &:ipv4_private?).ip_address, 'Host to bind LiveReload API server to'
     option :ignore, [], 'Array of patterns for paths that must be ignored'
     option :js_port, nil, 'Port to connect the LiveReload Javascript to (if different than :port)'
@@ -43,7 +43,7 @@ module Middleman
         end
 
         files.changed do |file|
-          next if files.respond_to?(:ignored?) && files.send(:ignored?, file)
+          next if ignore.any? { |i| file.to_s.match(i) }
 
           logger.debug "LiveReload: File changed - #{file}"
 
@@ -68,7 +68,7 @@ module Middleman
         end
 
         files.deleted do |file|
-          next if files.respond_to?(:ignored?) && files.send(:ignored?, file)
+          next if files.respond_to?(:ignore?) && files.send(:ignore?, file)
 
           logger.debug "LiveReload: File deleted - #{file}"
 

--- a/lib/middleman-livereload/extension.rb
+++ b/lib/middleman-livereload/extension.rb
@@ -7,7 +7,7 @@ module Middleman
     option :apply_js_live, true, 'Apply JS changes live, without reloading'
     option :apply_css_live, true, 'Apply CSS changes live, without reloading'
     option :no_swf, true, 'Disable Flash WebSocket polyfill for browsers that support native WebSockets'
-    option :host, Socket.ip_address_list.find(->{ Addrinfo.ip 'localhost' }, &:ipv4_private?).ip_address, 'Host to bind LiveReload API server to'
+    option :host, "0.0.0.0", 'Host to bind LiveReload API server to'
     option :ignore, [], 'Array of patterns for paths that must be ignored'
     option :js_port, nil, 'Port to connect the LiveReload Javascript to (if different than :port)'
     option :js_host, nil, 'Host to connect LiveReload Javascript to (if different than :host)'

--- a/middleman-livereload.gemspec
+++ b/middleman-livereload.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |s|
   s.files = `git ls-files -z`.split("\0")
   s.test_files = `git ls-files -z -- {fixtures,features}/*`.split("\0")
   s.require_paths = ["lib"]
-  s.required_ruby_version = '>= 1.9.3'
-  s.add_dependency("middleman-core", [">= 3.3"])
+  s.required_ruby_version = '>= 2.1.0'
+  s.add_dependency("middleman-core", ["~> 4.1.1"])
   s.add_runtime_dependency('rack-livereload', ['~> 0.3.15'])
   s.add_runtime_dependency('em-websocket', ['~> 0.5.1'])
 end


### PR DESCRIPTION
This should also work on middleman 4.0, but I have not tested that.

Documentation was unclear as to how the `:ignore` option should work, but it didn't seem to be working :( So this makes it accept regular expressions.