### PR TITLE
Make ignore work

### DIFF
--- a/lib/middleman-livereload/extension_3_1.rb
+++ b/lib/middleman-livereload/extension_3_1.rb
@@ -45,8 +45,8 @@ module Middleman
         end
 
         ignored = lambda do |file|
-          return true if files.respond_to?(:ignored) && files.send(:ignored?, file)
-          extension.options.ignore.any? { |i| file.to_s.match(i) }
+          return true if files.respond_to?(:ignored?) && files.send(:ignored?, file)
+          ignore.any? { |i| file.to_s.match(i) }
         end
 
         files.changed do |file|


### PR DESCRIPTION
After the extension syntax change *ignore* stopped working. With this change it works again.