### PR TITLE
Fix crash when reloading config.rb

### DIFF
--- a/lib/middleman-livereload/extension_3_1.rb
+++ b/lib/middleman-livereload/extension_3_1.rb
@@ -25,8 +25,6 @@ module Middleman
         return unless app.environment == :development
       end
 
-      @reactor = nil
-
       port = options.port.to_i
       host = options.host
       js_port = options.js_port || port
@@ -40,11 +38,7 @@ module Middleman
       extension = self
 
       app.ready do
-        if @reactor
-          @reactor.app = self
-        else
-          @reactor = ::Middleman::LiveReload::Reactor.new(options_hash, self)
-        end
+        reactor = ::Middleman::LiveReload::Reactor.create(options_hash, self)
 
         ignored = lambda do |file|
           return true if app.files.respond_to?(:ignored?) && app.files.send(:ignored?, file)
@@ -73,7 +67,7 @@ module Middleman
             reload_path = livereload_css_target
           end
 
-          @reactor.reload_browser(reload_path)
+          reactor.reload_browser(reload_path)
         end
 
         app.files.deleted do |file|
@@ -81,7 +75,7 @@ module Middleman
 
           logger.debug "LiveReload: File deleted - #{file}"
 
-          @reactor.reload_browser("#{Dir.pwd}/#{file}")
+          reactor.reload_browser("#{Dir.pwd}/#{file}")
         end
 
         # Use the vendored livereload.js source rather than trying to get it from Middleman

--- a/lib/middleman-livereload/reactor.rb
+++ b/lib/middleman-livereload/reactor.rb
@@ -7,6 +7,16 @@ module Middleman
     class Reactor
       attr_reader :thread, :web_sockets, :app
 
+      def self.create(options, app)
+        if @reactor
+          @reactor.app = app
+        else
+          @reactor = new(options, app)
+        end
+
+        @reactor
+      end
+
       def initialize(options, app)
         @app = app
         @web_sockets = []


### PR DESCRIPTION
The previous implementation cached the reactor on the extension instance. However, the instance doesn’t survive the reload and would try to create a new reactor. This failed, because the previous reactor wasn’t stopped.

This change caches the reactor in the ractor class itself so it’s still there after the reload.