### PR TITLE
Update rack-live reload version

### DIFF
--- a/middleman-livereload.gemspec
+++ b/middleman-livereload.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.required_ruby_version = '>= 1.9.3'
   s.add_dependency("middleman-core", [">= 3.3"])
-  s.add_runtime_dependency('rack-livereload', ['~> 0.3.16'])
+  s.add_runtime_dependency('rack-livereload', ['~> 0.6.1'])
   s.add_runtime_dependency('em-websocket', ['~> 0.5.1'])
 end


### PR DESCRIPTION
middleman-livereload does not work with the latest Middleman Version (4.6.0)

> Internal Server Error
> uppercase character in header name: Content-Type

It seems, like with Rack 3.0, response headers are enforced to be lower case ( https://github.com/rack/rack/issues/1592 )

Middleman 4.6.0 upgraded the rack dependency to 3.0 and accordingly downcased rack headers ( https://github.com/middleman/middleman/blob/main/CHANGELOG.md#460 ) 

The old version of rack-livereload does not work with rack 3.0 because it sends its response headers in Title Case. This has since been fixed ( https://github.com/jaredmdobson/rack-livereload/issues/11 ) 